### PR TITLE
Adding various audio manipulation and variation util nodes

### DIFF
--- a/SampleDiffusion/EXT_AudioManipulation.py
+++ b/SampleDiffusion/EXT_AudioManipulation.py
@@ -1,0 +1,260 @@
+import torch
+import numpy as np
+import importlib
+import subprocess
+import sys
+
+
+def hijack_import(importname, installname):
+    try:
+        importlib.import_module(importname)
+    except ModuleNotFoundError:
+        print(f"Import failed for {importname}, Installing {installname}")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", installname])
+
+
+hijack_import("librosa", "librosa")
+
+import librosa.effects
+
+
+# -----------------
+# AUDIO ARRANGEMENT
+# -----------------
+
+
+class JoinAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor_1": ("AUDIO", ),
+                "tensor_2": ("AUDIO", ),
+                "gap": ("INT", {"default": 0, "min": -1e9, "max": 1e9, "step": 1}),
+                "overlap_method": (("overwrite", "linear", "sigmoid"), {"default": "sigmoid"})
+                },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+                },
+            }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("joined_tensor", "sample_rate")
+    FUNCTION = "join_audio"
+
+    CATEGORY = "Audio/Arrangement"
+
+    def join_audio(self, tensor_1, tensor_2, gap, overlap_method, sample_rate):
+        joined_length = tensor_1.size(2) + tensor_2.size(2) + gap
+        joined_tensor = torch.zeros((tensor_1.size(0), tensor_1.size(1), joined_length), device=tensor_1.device)
+        tensor_1_masked = tensor_1.clone()
+        tensor_2_masked = tensor_2.clone()
+
+        # Overlapping
+        if gap < 0:
+            gap_abs = abs(gap)
+            mask = np.ones(gap_abs)
+            if overlap_method == 'linear':
+                mask = np.linspace(0.0, 1.0, num=gap_abs)
+            elif overlap_method == 'sigmoid':
+                k = 6
+                mask = np.linspace(-1.0, 1.0, num=gap_abs)
+                mask = 1 / (1 + np.exp(-mask * k))
+            mask = torch.from_numpy(mask).to(device=tensor_1.device)
+            tensor_1_masked[:, :, -gap_abs:] *= 1.0 - mask
+            tensor_2_masked[:, :, :gap_abs] *= mask
+
+        joined_tensor[:, :, :tensor_1.size(2)] += tensor_1_masked
+        joined_tensor[:, :, tensor_1.size(2) + gap:] += tensor_2_masked
+
+        return joined_tensor, sample_rate
+
+
+class BatchJoinAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "batch_tensor": ("AUDIO",),
+                "gap": ("INT", {"default": 0, "min": -1e9, "max": 1e9, "step": 1}),
+                "overlap_method": (("overwrite", "linear", "sigmoid"), {"default": "sigmoid"})
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("joined_tensor", "sample_rate")
+    FUNCTION = "batch_join_audio"
+
+    CATEGORY = "Audio/Arrangement"
+
+    def batch_join_audio(self, batch_tensor, gap, overlap_method, sample_rate):
+        joined_length = batch_tensor.size(2) * batch_tensor.size(0) + gap * (batch_tensor.size(0) - 1)
+        joined_tensor = torch.zeros((1, batch_tensor.size(1), joined_length), device=batch_tensor.device)
+        tensor_masked = batch_tensor.clone()
+
+        # Overlapping
+        if gap < 0:
+            gap_abs = abs(gap)
+            mask = np.ones(gap_abs)
+            if overlap_method == 'linear':
+                mask = np.linspace(0.0, 1.0, num=gap_abs)
+            elif overlap_method == 'sigmoid':
+                k = 6
+                mask = np.linspace(-1.0, 1.0, num=gap_abs)
+                mask = 1 / (1 + np.exp(-mask * k))
+            mask = torch.from_numpy(mask).to(device=batch_tensor.device)
+            tensor_masked[:-1, :, -gap_abs:] *= 1.0 - mask
+            tensor_masked[1:, :, :gap_abs] *= mask
+
+        for i, sample in enumerate(tensor_masked):
+            sample_start = (batch_tensor.size(2) + gap) * i
+            sample_end = sample_start + batch_tensor.size(2)
+            joined_tensor[:, :, sample_start:sample_end] += sample
+
+        return joined_tensor, sample_rate
+    
+
+class CutAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+                "start": ("INT",),
+                "end": ("INT",),
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("cut_tensor", "sample_rate")
+    FUNCTION = "cut_audio"
+
+    CATEGORY = "Audio/Arrangement"
+
+    def cut_audio(self, tensor, start, end, sample_rate):
+        return tensor.clone()[:, :, start:end], sample_rate
+
+
+class DuplicateAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+                "count": ("INT", {"default": 1, "min": 1, "max": 1024, "step": 1}),
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("out_tensor", "sample_rate")
+    FUNCTION = "duplicate_audio"
+
+    CATEGORY = "Audio/Arrangement"
+
+    def duplicate_audio(self, tensor, count, sample_rate):
+        return tensor.repeat(count, 1, 1), sample_rate
+
+
+# ------------------
+# AUDIO MANIPULATION
+# ------------------
+
+
+class StretchAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO", ),
+                "rate": ("FLOAT", {"default": 1.0, "min": 1e-9, "max": 1e9, "step": 0.1})
+                },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+                },
+            }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("tensor", "sample_rate")
+    FUNCTION = "stretch_audio"
+
+    CATEGORY = "Audio/Manipulation"
+
+    def stretch_audio(self, tensor, rate, sample_rate):
+        y = tensor.cpu().numpy()
+        y = librosa.effects.time_stretch(y, rate=rate)
+        tensor_out = torch.from_numpy(y).to(device=tensor.device)
+
+        return tensor_out, sample_rate
+
+
+class ReverseAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("tensor", "sample_rate")
+    FUNCTION = "reverse_audio"
+
+    CATEGORY = "Audio/Manipulation"
+
+    def reverse_audio(self, tensor, sample_rate):
+        return torch.flip(tensor.clone(), (2,)), sample_rate
+
+
+class ResampleAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1}),
+                "sample_rate_target": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1}),
+            },
+            "optional": {},
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("out_tensor", "sample_rate")
+    FUNCTION = "resample_audio"
+
+    CATEGORY = "Audio/Manipulation"
+
+    def resample_audio(self, tensor, sample_rate, sample_rate_target):
+        y = tensor.cpu().numpy()
+        y = librosa.resample(y, sample_rate, sample_rate_target)
+        tensor_out = torch.from_numpy(y).to(device=tensor.device)
+
+        return tensor_out, sample_rate_target
+
+
+# --------
+# ENVELOPE
+# --------
+
+
+NODE_CLASS_MAPPINGS = {
+    'JoinAudio': JoinAudio,
+    'BatchJoinAudio': BatchJoinAudio,
+    'CutAudio': CutAudio,
+    'DuplicateAudio': DuplicateAudio,
+    'StretchAudio': StretchAudio,
+    'ReverseAudio': ReverseAudio,
+    'ResampleAudio': ResampleAudio
+}

--- a/SampleDiffusion/EXT_VariationUtils.py
+++ b/SampleDiffusion/EXT_VariationUtils.py
@@ -1,0 +1,198 @@
+import torch
+import torchaudio
+import os
+import soundfile as sf
+
+from comfy.model_management import get_torch_device
+from custom_nodes.SampleDiffusion.EXT_SampleDiffusion import AudioInference
+from diffusion_library.sampler import SamplerType
+from diffusion_library.scheduler import SchedulerType
+
+# -------------
+# LIST CREATION
+# -------------
+
+
+# Split up audio into a sequence of smaller clips (represented as a 4d tensor) to be processed individually
+class SliceAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+                "clip_size": ("INT", {"default": 1, "min": 1, "max": 1e9, "step": 1}),
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO_LIST", "INT")
+    RETURN_NAMES = ("tensor_list", "sample_rate")
+    FUNCTION = "slice_audio"
+
+    CATEGORY = "Audio/VariationUtils"
+
+    def slice_audio(self, tensor, clip_size, sample_rate):
+        return list(torch.split(tensor.clone(), clip_size, 2)), sample_rate
+
+
+class BatchToList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO_LIST", "INT")
+    RETURN_NAMES = ("tensor_list", "sample_rate")
+    FUNCTION = "batch_to_list"
+
+    CATEGORY = "Audio/VariationUtils"
+
+    def batch_to_list(self, tensor, sample_rate):
+        return list(torch.split(tensor.clone(), 1, 0)), sample_rate
+
+
+class LoadAudioDir:
+    @classmethod
+    def INPUT_TYPES(cls):
+        """
+        Input Types
+        """
+        return {
+            "required": {
+                "dir_path": ("STRING", {}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "AUDIO_LIST", "INT")
+    RETURN_NAMES = ("dir_path", "tensor_list", "sample_rate")
+    FUNCTION = "load_audio_dir"
+    OUTPUT_NODE = True
+
+    CATEGORY = "Audio/VariationUtils"
+
+    def load_audio_dir(self, dir_path):
+        tensor_list = []
+        sample_rate = None
+
+        if dir_path == '':
+            return dir_path, tensor_list, sample_rate
+
+        for file_path in os.listdir(dir_path):
+            if os.path.isfile(f'{dir_path}/{file_path}'):
+                if file_path.endswith('.mp3'):
+                    if os.path.exists(file_path.replace('.mp3', '') + '.wav'):
+                        file_path = file_path.replace('.mp3', '') + '.wav'
+                    else:
+                        data, sample_rate = sf.read(file_path)
+                        sf.write(file_path.replace('.mp3', '') + '.wav', data, sample_rate)
+
+                    os.remove(file_path.replace('.wav', '.mp3'))
+
+                waveform, sample_rate = torchaudio.load(f'{dir_path}/{file_path}')
+                waveform = waveform.to(get_torch_device())
+                waveform = waveform.unsqueeze(0)
+                tensor_list.append(waveform)
+
+        return dir_path, tensor_list, sample_rate
+
+# ----------------
+# LIST AGGREGATION
+# ----------------
+
+
+class ConcatAudioList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor_list": ("AUDIO_LIST",)
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("tensor", "sample_rate")
+    FUNCTION = "concat_audio"
+
+    CATEGORY = "Audio/VariationUtils"
+
+    def concat_audio(self, tensor_list, sample_rate):
+        return torch.cat(tensor_list, 2), sample_rate
+
+# ----------
+# PROCESSING
+# ----------
+
+
+# Perform variation on each audio tensor in a list
+class SequenceVariation:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        """
+        Input Types
+        """
+        return {
+            "required": {
+                "audio_model": ("DD_MODEL",),
+                "batch_size": ("INT", {"default": 1, "min": 1, "max": 1e9, "step": 1}),
+                "steps": ("INT", {"default": 50, "min": 1, "max": 1e9, "step": 1}),
+                "sampler": (SamplerType._member_names_, {"default": "V_IPLMS"}),
+                "sigma_min": ("FLOAT", {"default": 0.1, "min": 0.0, "max": 1280, "step": 0.01}),
+                "sigma_max": ("FLOAT", {"default": 50, "min": 0.0, "max": 1280, "step": 0.01}),
+                "rho": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 128.0, "step": 0.01}),
+                "scheduler": (SchedulerType._member_names_, {"default": "V_CRASH"}),
+                "noise_level": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "seed": ("INT", {"default": -1}),
+                "tensor_list": ("AUDIO_LIST",)
+            },
+            "optional": {},
+        }
+
+    RETURN_TYPES = ("AUDIO_LIST", "INT")
+    RETURN_NAMES = ("tensor_list", "sample_rate")
+    FUNCTION = "do_variation"
+
+    CATEGORY = "Audio/VariationUtils"
+
+    def do_variation(self, audio_model, batch_size, steps, sampler, sigma_min, sigma_max, rho, scheduler, tensor_list, noise_level=0.7, seed=-1):
+        audio_inference = AudioInference()
+        tensor_list_out = []
+        sample_rate = 44100
+        for tensor in tensor_list:
+            _, tensor_out, sample_rate = audio_inference.do_sample(
+                audio_model=audio_model,
+                mode='Variation',
+                batch_size=batch_size,
+                steps=steps,
+                sampler=sampler,
+                sigma_min=sigma_min,
+                sigma_max=sigma_max,
+                rho=rho,
+                scheduler=scheduler,
+                input_tensor=tensor,
+                noise_level=noise_level,
+                seed=seed)
+            tensor_list_out.append(tensor_out)
+        return tensor_list_out, sample_rate
+
+
+NODE_CLASS_MAPPINGS = {
+    'SliceAudio': SliceAudio,
+    'BatchToList': BatchToList,
+    'LoadAudioDir': LoadAudioDir,
+    'ConcatAudioList': ConcatAudioList,
+    'SequenceVariation': SequenceVariation
+}


### PR DESCRIPTION
The AudioManipulation nodes should work with any of the other audio nodes that operate on single tensors. VariationUtils includes an inference node that loops on a list of tensors, as well as nodes to create lists and aggregate them back into single tensors.