### PR TITLE
Fixes and additons

### DIFF
--- a/SampleDiffusion/EXT_AudioManipulation.py
+++ b/SampleDiffusion/EXT_AudioManipulation.py
@@ -163,7 +163,6 @@ class DuplicateAudio:
     def duplicate_audio(self, tensor, count, sample_rate):
         return tensor.repeat(count, 1, 1), sample_rate
 
-
 # ------------------
 # AUDIO MANIPULATION
 # ------------------
@@ -224,10 +223,11 @@ class ResampleAudio:
         return {
             "required": {
                 "tensor": ("AUDIO",),
-                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1}),
                 "sample_rate_target": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1}),
             },
-            "optional": {},
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
         }
 
     RETURN_TYPES = ("AUDIO", "INT")
@@ -238,7 +238,7 @@ class ResampleAudio:
 
     def resample_audio(self, tensor, sample_rate, sample_rate_target):
         y = tensor.cpu().numpy()
-        y = librosa.resample(y, sample_rate, sample_rate_target)
+        y = librosa.resample(y, orig_sr=sample_rate, target_sr=sample_rate_target)
         tensor_out = torch.from_numpy(y).to(device=tensor.device)
 
         return tensor_out, sample_rate_target

--- a/SampleDiffusion/EXT_AudioManipulation.py
+++ b/SampleDiffusion/EXT_AudioManipulation.py
@@ -115,6 +115,36 @@ class BatchJoinAudio:
             joined_tensor[:, :, sample_start:sample_end] += sample
 
         return joined_tensor, sample_rate
+
+
+class LayerAudio:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor_1": ("AUDIO", ),
+                "tensor_2": ("AUDIO", ),
+                "weight_1": ("FLOAT", {"default": 1.0, "min": -1e9, "max": 1e9, "step": 1}),
+                "weight_2": ("FLOAT", {"default": 1.0, "min": -1e9, "max": 1e9, "step": 1})
+                },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+                },
+            }
+
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("tensor", "sample_rate")
+    FUNCTION = "layer_audio"
+
+    CATEGORY = "Audio/Arrangement"
+
+    def layer_audio(self, tensor_1, tensor_2, weight_1, weight_2, sample_rate):
+        layered_length = max(tensor_1.size(2), tensor_2.size(2))
+        layered_tensor = torch.zeros((tensor_1.size(0), tensor_1.size(1), layered_length), device=tensor_1.device)
+        layered_tensor[:, :, :tensor_1.size(2)] += tensor_1 * weight_1
+        layered_tensor[:, :, :tensor_2.size(2)] += tensor_2 * weight_2
+
+        return layered_tensor, sample_rate
     
 
 class CutAudio:
@@ -244,6 +274,36 @@ class ResampleAudio:
         return tensor_out, sample_rate_target
 
 
+class SeparatePercussion:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tensor": ("AUDIO",),
+                "kernel_size": ("INT", {"default": 31, "min": 1, "max": 1e9, "step": 1}),
+                "power": ("FLOAT", {"default": 2.0, "min": 0, "max": 1e9, "step": 0.1}),
+                "margin": ("FLOAT", {"default": 1.0, "min": 0, "max": 1e9, "step": 0.1})
+
+            },
+            "optional": {
+                "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "AUDIO", "INT")
+    RETURN_NAMES = ("harmonic_tensor", "percussion_tensor", "sample_rate")
+    FUNCTION = "separate_audio"
+
+    CATEGORY = "Audio/Manipulation"
+
+    def separate_audio(self, tensor, kernel_size, power, margin, sample_rate):
+        y = tensor.cpu().numpy()
+        h, p = librosa.effects.hpss(y, kernel_size=kernel_size, power=power, margin=margin)
+        harmonic_tensor = torch.from_numpy(h).to(device=tensor.device)
+        percussion_tensor = torch.from_numpy(p).to(device=tensor.device)
+
+        return harmonic_tensor, percussion_tensor, sample_rate
+
 # --------
 # ENVELOPE
 # --------
@@ -252,9 +312,11 @@ class ResampleAudio:
 NODE_CLASS_MAPPINGS = {
     'JoinAudio': JoinAudio,
     'BatchJoinAudio': BatchJoinAudio,
+    'LayerAudio': LayerAudio,
     'CutAudio': CutAudio,
     'DuplicateAudio': DuplicateAudio,
     'StretchAudio': StretchAudio,
     'ReverseAudio': ReverseAudio,
-    'ResampleAudio': ResampleAudio
+    'ResampleAudio': ResampleAudio,
+    'SeparatePercussion': SeparatePercussion
 }

--- a/SampleDiffusion/EXT_SampleDiffusion.py
+++ b/SampleDiffusion/EXT_SampleDiffusion.py
@@ -283,7 +283,7 @@ class SaveAudio():
     FUNCTION = "save_audio_ui"
     OUTPUT_NODE = True
 
-    CATEGORY = "Audio/SampleDiffusion"
+    CATEGORY = "Audio"
 
     def save_audio_ui(self, tensor, output_path, sample_rate, id_string, tame):
         return (save_audio(audio_out=(0.5 * tensor).clamp(-1,1) if(tame == 'Enabled') else tensor, output_path=output_path, sample_rate=sample_rate, id_str=id_string), )
@@ -311,7 +311,7 @@ class LoadAudio():
     FUNCTION = "LoadAudio"
     OUTPUT_NODE = True
 
-    CATEGORY = "Audio/SampleDiffusion"
+    CATEGORY = "Audio"
 
     def LoadAudio(self, file_path):
         if file_path == '':
@@ -398,7 +398,7 @@ class PreviewAudioFile():
     FUNCTION = "PreviewAudioFile"
     OUTPUT_NODE = True
 
-    CATEGORY = "Audio/SampleDiffusion"
+    CATEGORY = "Audio"
 
     def PreviewAudioFile(self, paths):
         # fix slashes
@@ -426,7 +426,7 @@ class PreviewAudioTensor():
     FUNCTION = "PreviewAudioTensor"
     OUTPUT_NODE = True
 
-    CATEGORY = "Audio/SampleDiffusion"
+    CATEGORY = "Audio"
 
     def PreviewAudioTensor(self, tensor, sample_rate, tame):
         # fix slashes

--- a/SampleDiffusion/EXT_VariationUtils.py
+++ b/SampleDiffusion/EXT_VariationUtils.py
@@ -181,7 +181,7 @@ class GetSingle:
         return {
             "required": {
                 "tensor_list": ("AUDIO_LIST",),
-                "index": ("INT", {"default": 0, "min": 1, "max": 1e9, "step": 1})
+                "index": ("INT", {"default": 1, "min": 1, "max": 1e9, "step": 1})
             },
             "optional": {
                 "sample_rate": ("INT", {"default": 44100, "min": 1, "max": 1e9, "step": 1, "forceInput": True}),
@@ -203,7 +203,7 @@ class GetSingle:
 
 
 # Perform variation on each audio tensor in a list
-class SequenceVariation:
+class BulkVariation:
     def __init__(self):
         pass
 
@@ -233,7 +233,7 @@ class SequenceVariation:
     RETURN_NAMES = ("tensor_list", "sample_rate")
     FUNCTION = "do_variation"
 
-    CATEGORY = "Audio/VariationUtils"
+    CATEGORY = "Audio/SampleDiffusion"
 
     def do_variation(self, audio_model, batch_size, steps, sampler, sigma_min, sigma_max, rho, scheduler, tensor_list, noise_level=0.7, seed=-1):
         audio_inference = AudioInference()
@@ -264,5 +264,5 @@ NODE_CLASS_MAPPINGS = {
     'ListToBatch': ListToBatch,
     'ConcatAudioList': ConcatAudioList,
     'GetSingle': GetSingle,
-    'SequenceVariation': SequenceVariation
+    'BulkVariation': BulkVariation
 }


### PR DESCRIPTION
- Fixed ResampleAudio to work properly and it now takes the input sample rate as a node connection
- Added GetSingle to retrieve a single tensor from a list by index
- Added LayerAudio
- Added SeperatePercussion: uses Harmonic Percussive Source Seperation from librosa to create two different tracks. Has some parameters, no idea how they work but they are there to mess around with
- Moved the audio file IO and preview nodes out of Audio/SampleDiffusion into the main Audio folder so they are easier to find. Based this on how the image stuff is organized